### PR TITLE
Try reading .bib files directly when not stored in the files object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 var parse = require('bib2json');
 var extname = require('path').extname;
+var fs = require('fs');
+var joinPaths = require('path').join;
 var handlebars = require('handlebars');
 
 /**
@@ -37,10 +39,13 @@ module.exports = function(options) {
 
         keys.forEach(function(coll) {
             let filename = options.collections[coll];
-            if (!(filename in files) || !bibtex(filename)) {
-                throw new Error('Cannot find file ' + filename);
+            if (!bibtex(filename)) {
+                throw new Error('File is not bibtex: ' + filename)
             }
-            var bibdata_raw = parse(files[filename].contents.toString());
+            var bibliographyAsString = (filename in files)
+                ? files[filename].contents.toString()
+                : fs.readFileSync(joinPaths(metalsmith._source, filename), 'utf8');
+            var bibdata_raw = parse(bibliographyAsString);
             var bibdata = {};
             bibdata_raw.entries.forEach(function(entry) {
                 bibdata[entry.EntryKey] = entry.Fields;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "bib2json": "0.0.1",
+    "fs": "0.0.1-security",
     "handlebars": "^4.0.5",
     "path": "^0.12.7"
   },


### PR DESCRIPTION
Previously, all bibliography files mentioned in the collections option were
assumed to have their content provided in metalsmith’s files object. Other
metalsmith plugins violate this assumption, for instance, to enable recompiling
only a subset of the source files.

This change implements a fallback: if a bibliography file is not present in the
files object, we then try to read the file directly from the filesystem. This
allows metalsmith-bibtex to coexist with plugins like metalsmith-watch.